### PR TITLE
Avoid creating extra body div in Modal if description is empty.

### DIFF
--- a/src/modal.rs
+++ b/src/modal.rs
@@ -96,9 +96,12 @@ impl Component for Modal {
                     >{ &ctx.props().title }</h1>
                 </header>
 
-                <div class="pf-c-modal-box__body">
-                    <p>{ &ctx.props().description }</p>
-                </div>
+
+                if !&ctx.props().description.is_empty() {
+                    <div class="pf-c-modal-box__body">
+                        <p>{ &ctx.props().description }</p>
+                    </div>
+                }
 
                 { for ctx.props().children.iter().map(|c|{
                    {html!{


### PR DESCRIPTION
Before this PR, if you create a modal that has children but not a description, there'll be an empty div with an extra 16 px of padding above the children. This PR only creates the div for the description text if that text is not empty.