### PR TITLE
fixes `Nav` styling issues on chrome

### DIFF
--- a/src/components/nav/mod.rs
+++ b/src/components/nav/mod.rs
@@ -24,7 +24,9 @@ pub struct NavProperties {
 pub fn nav(props: &NavProperties) -> Html {
     html! {
         <nav class="pf-c-nav" aria-label="Global">
-            { for props.children.iter() }
+            <ul class="pf-c-nav__list">
+                { for props.children.iter() }
+            </ul>
         </nav>
     }
 }


### PR DESCRIPTION
added the `ul` tag around `li` tags as on the patternfly4 example page

source: https://www.patternfly.org/v4/components/navigation/html


bug on quickstarte page in chromium:
![image](https://user-images.githubusercontent.com/2470864/232226053-299c6d17-828d-456d-a127-e9c16af10dec.png)


fixed after patch