### PR TITLE
Modal components

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ uuid = { version = "1", features = ["v4", "js"] }
 wasm-bindgen = "0.2"
 wasm-bindgen-futures = "0.4"
 yew = "0.20"
+yew-hooks = "0.2.0"
 yew-nested-router = { version = "0.2.0", optional = true }
 
 web-sys = { version = "0.3", features = [


### PR DESCRIPTION
a55182e should read "Refactor modal component to use yew-hooks. Add yew-hooks as a dependency"

I would like your views on adding yew-hooks as a dependency.

I tried refactoring the Modal & About components so that they shared more code, but the differences in the exit buttons (verified the mark up differences with paternfly) were causing problems I couldn't find an easy solution. I don't like duplicating the code, but given that this is only used by two components, its a trade off between that and complexity.

Also to note the  `About` component attributes are significantly different to the patternfly attributes:
- brand_src, brand_alt, and the children are required
- `title` is `productName` in pf and is not required
- `strapline` is `trademark` in pf and only accepts strings, not html
- `logo` is called ` backgroundImageSrc` in pf. and is a far better description imho
- `hero_style` allows custom styling, pf does not.

Finally, the `About` component is called `AboutModal` in pf