### PR TITLE
Modal: disable close button

### DIFF
--- a/src/components/modal.rs
+++ b/src/components/modal.rs
@@ -46,8 +46,8 @@ pub struct ModalProperties {
     pub onclose: Option<Callback<()>>,
 
     /// Disable close button
-    #[prop_or_default]
-    pub disable_close_button: bool,
+    #[prop_or(true)]
+    pub show_close: bool,
 
     /// Disable closing the modal when the escape key is pressed
     #[prop_or_default]
@@ -129,21 +129,15 @@ pub fn modal(props: &ModalProperties) -> Html {
             aria-describedby="modal-description"
             ref={node_ref}
         >
-            {
-                if !props.disable_close_button {
-                    html! {
-                        <button
-                            class="pf-c-button pf-m-plain"
-                            type="button"
-                            aria-label="Close dialog"
-                            onclick={onclose.reform(|_|())}
-                        >
-                            <i class="fas fa-times" aria-hidden="true"></i>
-                        </button>
-                    }
-                } else {
-                    html!{}
-                }
+            if props.show_close {
+                <button
+                    class="pf-c-button pf-m-plain"
+                    type="button"
+                    aria-label="Close dialog"
+                    onclick={onclose.reform(|_|())}
+                >
+                    <i class="fas fa-times" aria-hidden="true"></i>
+                </button>
             }
 
             <header class="pf-c-modal-box__header">

--- a/src/components/modal.rs
+++ b/src/components/modal.rs
@@ -45,6 +45,10 @@ pub struct ModalProperties {
     #[prop_or_default]
     pub onclose: Option<Callback<()>>,
 
+    /// Disable close button
+    #[prop_or_default]
+    pub disable_close_button: bool,
+
     /// Disable closing the modal when the escape key is pressed
     #[prop_or_default]
     pub disable_close_escape: bool,
@@ -125,14 +129,22 @@ pub fn modal(props: &ModalProperties) -> Html {
             aria-describedby="modal-description"
             ref={node_ref}
         >
-            <button
-                class="pf-c-button pf-m-plain"
-                type="button"
-                aria-label="Close dialog"
-                onclick={onclose.reform(|_|())}
-            >
-                <i class="fas fa-times" aria-hidden="true"></i>
-            </button>
+            {
+                if !props.disable_close_button {
+                    html! {
+                        <button
+                            class="pf-c-button pf-m-plain"
+                            type="button"
+                            aria-label="Close dialog"
+                            onclick={onclose.reform(|_|())}
+                        >
+                            <i class="fas fa-times" aria-hidden="true"></i>
+                        </button>
+                    }
+                } else {
+                    html!{}
+                }
+            }
 
             <header class="pf-c-modal-box__header">
                 <h1


### PR DESCRIPTION
Sometimes you don't want to allow user to close modal window (for example if you wait for operation to finish). 