### PR TITLE
feat(pagination): add is_bottom

### DIFF
--- a/generator/icons/icons.mjs
+++ b/generator/icons/icons.mjs
@@ -144,6 +144,13 @@ export const iconsData = [
   },
   {
     "Style": "fas",
+    "Name": "fa-caret-up",
+    "React_name": "CaretUpIcon",
+    "Type": "Framework",
+    "Contextual_usage": "Indicates the ability to acces option panels for components like drop-downs, filters and page ranges",
+  },
+  {
+    "Style": "fas",
     "Name": "fa-caret-down",
     "React_name": "CaretDownIcon",
     "Type": "Framework",

--- a/src/components/pagination.rs
+++ b/src/components/pagination.rs
@@ -1,7 +1,7 @@
 //! Pagination controls
 use crate::{
-    next::TextInput, on_enter, Button, ButtonVariant, Icon, InputState, ValidationContext,
-    Validator,
+    next::TextInput, on_enter, AsClasses, Button, ButtonVariant, ExtendClasses, Icon, InputState,
+    ValidationContext, Validator,
 };
 use yew::prelude::*;
 use yew_hooks::use_click_away;
@@ -12,17 +12,19 @@ pub enum PaginationPosition {
     Bottom,
 }
 
-impl PaginationPosition {
-    fn menu_classes(&self) -> Classes {
+impl AsClasses for PaginationPosition {
+    fn extend_classes(&self, classes: &mut Classes) {
         match self {
-            PaginationPosition::Top => classes!("pf-c-options-menu"),
-            PaginationPosition::Bottom => classes!("pf-c-options-menu", "pf-m-top"),
+            Self::Top => {}
+            Self::Bottom => classes.push(classes!("pf-m-top")),
         }
     }
+}
 
+impl PaginationPosition {
     fn toggle_icon(&self, expanded: bool) -> Icon {
         match (self, expanded) {
-            (PaginationPosition::Bottom, true) => Icon::CaretUp,
+            (Self::Bottom, true) => Icon::CaretUp,
             _ => Icon::CaretDown,
         }
     }
@@ -85,7 +87,9 @@ pub fn pagination(props: &PaginationProperties) -> Html {
     let expanded = use_state_eq(|| false);
 
     // The pagination menu : "1-20 of nnn"
-    let mut menu_classes = props.position.menu_classes();
+    let mut menu_classes = classes!("pf-c-options-menu");
+    menu_classes.extend_from(&props.position);
+
     if *expanded {
         menu_classes.push("pf-m-expanded");
     }

--- a/src/components/pagination.rs
+++ b/src/components/pagination.rs
@@ -6,6 +6,28 @@ use crate::{
 use yew::prelude::*;
 use yew_hooks::use_click_away;
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum PaginationPosition {
+    Top,
+    Bottom,
+}
+
+impl PaginationPosition {
+    fn menu_classes(&self) -> Classes {
+        match self {
+            PaginationPosition::Top => classes!("pf-c-options-menu"),
+            PaginationPosition::Bottom => classes!("pf-c-options-menu", "pf-m-top"),
+        }
+    }
+
+    fn toggle_icon(&self, expanded: bool) -> Icon {
+        match (self, expanded) {
+            (PaginationPosition::Bottom, true) => Icon::CaretUp,
+            _ => Icon::CaretDown,
+        }
+    }
+}
+
 /// Properties for [`Pagination`]
 #[derive(Clone, PartialEq, Properties)]
 pub struct PaginationProperties {
@@ -32,8 +54,8 @@ pub struct PaginationProperties {
     #[prop_or_default]
     pub style: AttrValue,
 
-    #[prop_or_default]
-    pub is_bottom: bool,
+    #[prop_or(PaginationPosition::Top)]
+    pub position: PaginationPosition,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -63,10 +85,7 @@ pub fn pagination(props: &PaginationProperties) -> Html {
     let expanded = use_state_eq(|| false);
 
     // The pagination menu : "1-20 of nnn"
-    let mut menu_classes = classes!("pf-c-options-menu");
-    if props.is_bottom {
-        menu_classes.push("pf-m-top");
-    }
+    let mut menu_classes = props.position.menu_classes();
     if *expanded {
         menu_classes.push("pf-m-expanded");
     }
@@ -230,7 +249,7 @@ pub fn pagination(props: &PaginationProperties) -> Html {
                             <b>{ total_entries }</b>
                         </span>
                         <span class="pf-c-options-menu__toggle-icon">
-                            { if props.is_bottom && *expanded { Icon::CaretUp } else { Icon::CaretDown } }
+                            { props.position.toggle_icon(*expanded)}
                         </span>
                     </Button>
                 </div>
@@ -292,7 +311,6 @@ pub fn pagination(props: &PaginationProperties) -> Html {
                         {oninput}
                         {onkeydown}
                         state={(*input_state).clone()}
-                        // value={((props.offset/props.selected_choice) + 1).to_string()}
                         value={(*input_text).clone().unwrap_or_default()}
                     />
                 if let Some(max_page) = max_page {

--- a/src/icon/generated.rs
+++ b/src/icon/generated.rs
@@ -47,6 +47,8 @@ pub enum Icon {
     #[cfg(feature = "icons-far")]
     OutlinedCalendarAlt,
     /// Indicates the ability to acces option panels for components like drop-downs, filters and page ranges
+    CaretUp,
+    /// Indicates the ability to acces option panels for components like drop-downs, filters and page ranges
     CaretDown,
     /// Represents status: Indicates a switch toggle is in the enabled position
     Check,
@@ -420,6 +422,7 @@ impl crate::core::AsClasses for Icon {
             Self::Bug => classes.extend(super::fas("fa-bug")),
             #[cfg(feature = "icons-far")]
             Self::OutlinedCalendarAlt => classes.extend(super::far("fa-calendar-alt")),
+            Self::CaretUp => classes.extend(super::fas("fa-caret-up")),
             Self::CaretDown => classes.extend(super::fas("fa-caret-down")),
             Self::Check => classes.extend(super::fas("fa-check")),
             Self::CheckCircle => classes.extend(super::fas("fa-check-circle")),


### PR DESCRIPTION
Inspired by the ReactJS equivalent of Patternfly https://www.patternfly.org/v4/components/pagination#bottom

## Pagination property `is_bottom`

- The `Pagination` component will accept an optional property `is_bottom: bool`, if `is_bottom=true` then the dropdown for selecting the number of items per page will appear on top of the component and using the appropriate arrow icons.

## Fix: input field of the pagination not synchronized with `offset` when multiple `<Pagination/>` components are present

A common use case is to have pagination on top and at the bottom of a table. Both pagination components must shown the same data. While creating this PR I found out that if there are more than 1 PAGINATION component then a change of the pages on one of them is not reflected in the other PAGINATION components (see video for better understanding).

[Screencast from 2023-06-19 09-54-24.webm](https://github.com/ctron/patternfly-yew/assets/2582866/e4dd7b5d-b4c1-42ab-9cb9-df8e4c0053c3)

This PR is also taking the opportunity to fix it and make it successfully work at https://github.com/ctron/patternfly-yew-quickstart/pull/23